### PR TITLE
Coerce SEREBII_USER_ID to string to prevent RuntimeError

### DIFF
--- a/serebii/models.py
+++ b/serebii/models.py
@@ -16,7 +16,7 @@ def pretty_join(items, word='and'):
 
 
 def get_soup(url):
-    request = requests.get(url, cookies={'bb_userid': settings.SEREBII_USER_ID, 'bb_password': settings.SEREBII_USER_PWHASH})
+    request = requests.get(url, cookies={'bb_userid': str(settings.SEREBII_USER_ID), 'bb_password': settings.SEREBII_USER_PWHASH})
     return BeautifulSoup(request.text, 'html.parser')
 
 


### PR DESCRIPTION
Soooo I found out if your settings.py has your userid listed as an integer rather than a string, it can't be properly cookified and causes a RuntimeError when you try to verify an account. I don't know whether you actually want to solve that problem by making this code change or just saying that you should enter your userid as a string rather than an integer (or maybe it's convention to do so, idk) or what, but I thought I'd just take this opportunity to try a simple merge and pull request.
