### PR TITLE
Generic Cutoff Check for Fics

### DIFF
--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -5,3 +5,4 @@ django-extra-views==0.7.1
 requests==2.7.0
 dj-database-url==0.3.0
 dj-static==0.0.6
+python-dateutil==2.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4==4.4.0
 django-extra-views==0.7.1
 django-toolbelt==0.0.1
 requests==2.7.0
+python-dateutil==2.4.2

--- a/serebii/models.py
+++ b/serebii/models.py
@@ -13,8 +13,12 @@ from django.contrib.auth.models import AbstractUser
 from bs4 import BeautifulSoup
 
 
+ELIGIBILITY_START = datetime.datetime(int(settings.YEAR), 1, 1, 0, 0, tzinfo=tz.tzutc())
+ELIGIBILITY_END = datetime.datetime(int(settings.YEAR) + 1, 1, 1, 0, 0, tzinfo=tz.tzutc())
+
+
 def check_in_awards_year(year, date):
-    if date < datetime.datetime(year, 12, 31, 23, 59, tzinfo=tz.tzutc()) and date > datetime.datetime(year, 1, 1, 0, 0, tzinfo=tz.tzutc()):
+    if date < ELIGIBILITY_END and date >= ELIGIBILITY_START:
         return True
     else:
         return False
@@ -36,12 +40,12 @@ def get_datetime_from_postdate(postdate, tzstring):
 
 def get_user_post_times(soup, author):
 
-    user_tz = get_timezone(soup)
+    board_tz = get_tz(soup)
 
     usernames = soup.find_all('a', class_="username")
-    postdates = soup.find_all('span', class_="postdate old")
+    postdates = soup.find_all('span', class_="postdate")
 
-    userposts = [get_datetime_from_postdate(posted.get_text(strip=True),  user_tz) for user, posted in zip(usernames, postdates) if author == user.get_text(strip=True)]
+    userposts = [get_datetime_from_postdate(posted.get_text(strip=True), board_tz) for user, posted in zip(usernames, postdates) if author == user.get_text(strip=True)]
 
     return userposts
 
@@ -50,13 +54,14 @@ def validate_fic_page(year, posts):
     return any([check_in_awards_year(year, date) for date in posts])
 
 
-def get_timezone(page):
+def get_tz(page):
+
     tz_text = page.find('div', id="footer_time").get_text()
     tz_bits = tz_text.split(' ')
     tz = tz_bits[4][:-1]
 
-    tz = '{}{:0>2d}00'.format(tz[0], int(tz[1:]))
-    return tz
+    board_tz = '{}{:0>2d}00'.format(tz[0], int(tz[1:]))
+    return board_tz
 
 
 def pretty_join(items, word='and'):
@@ -372,15 +377,15 @@ class Fic(SerebiiObject, models.Model):
             raise ValidationError(u"This thread does not seem to be a fanfic (it is not located in the Fan Fiction, Non-Pokémon Stories or Completed Fics forums). Please enter the link to a valid fanfic.")
         title_link = soup.find('span', class_="threadtitle").a
 
-        if post_id is not None and False:  # TODO: make it actually possible to nominate individual posts
+        if post_id is not None:  # TODO: make it actually possible to nominate individual posts
             # The fic starts in a particular post
             post = soup.find(id="post_%s" % post_id)
             title = post.find('h2', class_="posttitle").get_text(strip=True)
             author = get_post_author(post)
 
             # Make sure this was posted in the awards year
-            posted = post.find('span', class_="postdate old").get_text(strip=True)
-            posted_utc = get_datetime_from_postdate(posted,  get_timezone(soup))
+            posted = post.find('span', class_="postdate").get_text(strip=True)
+            posted_utc = get_datetime_from_postdate(posted,  get_tz(soup))
 
             if not check_in_awards_year(int(settings.YEAR), posted_utc):
                 raise ValidationError(u"This fanfic is not eligible for this year's awards. Please nominate a story posted between 00:00 January 1st {} and 23:59 UTC December 31st {}.".format(settings.YEAR, settings.YEAR))
@@ -403,17 +408,17 @@ class Fic(SerebiiObject, models.Model):
 
                 elif not soup.find('img', alt="Previous"):
                     # This is the first page!
-                    if userposts[0] > datetime.datetime(int(settings.YEAR), 12, 31, 23, 59, tzinfo=tz.tzutc()):
+                    if userposts[0] >= ELIGIBILITY_END:
                         # If the first post was made after the end of the awards year,
                         # the story can't possibly be eligible.
                         raise ValidationError(u"This fanfic is not eligible for this year's awards. Please nominate a story updated between 00:00 January 1st {} and 23:59 UTC December 31st {}.".format(settings.YEAR, settings.YEAR))
+
                 elif not soup.find('img', alt='Next'):
                     # This is the last page!
                     # I don't believe this should be able to happen
                     # But just in case...
-
-                    if userposts[-1] < datetime.datetime(int(settings.YEAR), 1, 1, 0, 0, tzinfo=tz.tzutc()):
-                        # If the first post was made before the beginning of the awards year,
+                    if userposts[-1] < ELIGIBILITY_START:
+                        # If the last post was made before the beginning of the awards year,
                         # the story can't possibly be eligible.
                         raise ValidationError(u"This fanfic is not eligible for this year's awards. Please nominate a story updated between 00:00 January 1st {} and 23:59 UTC December 31st {}.".format(settings.YEAR, settings.YEAR))
 
@@ -440,7 +445,7 @@ class Fic(SerebiiObject, models.Model):
                     if not validate_fic_page(int(settings.YEAR), userposts):
                         # If the author's first post on this page is from before the awards year,
                         # the story can't possibly be eligible.
-                        if userposts[0] < datetime.datetime(int(settings.YEAR), 1, 1, 0, 0, tzinfo=tz.tzutc()):
+                        if userposts[0] < ELIGIBILITY_START:
                             raise ValidationError(u"This fanfic is not eligible for this year's awards. Please nominate a story updated between 00:00 January 1st {} and 23:59 UTC December 31st {}.".format(settings.YEAR, settings.YEAR))
 
                         nextlink = ('showthread.php?{}/page{}'.format(thread_id, pagenum - 1))
@@ -448,6 +453,7 @@ class Fic(SerebiiObject, models.Model):
 
                     else:
                         break
+
 
         if thread_id is None:
             thread_id = FicPage.get_params_from_url(title_link['href'])['thread_id']

--- a/serebii/models.py
+++ b/serebii/models.py
@@ -11,11 +11,41 @@ from django.contrib.auth import logout
 from django.contrib.auth.models import AbstractUser
 from bs4 import BeautifulSoup
 
+
 def check_in_awards_year(year, date):
     if date < datetime.datetime(year, 12, 31, 23, 59, tzinfo=tz.tzutc()) and date > datetime.datetime(year, 1, 1, 0, 0, tzinfo=tz.tzutc()):
         return True
     else:
         return False
+
+
+def get_datetime_from_postdate(postdate, tzstring):
+
+    # First we have to get rid of "Yesterday" or "Today"
+    if 'Yesterday' in postdate:
+        yesterday = datetime.date.today() - datetime.timedelta(hours=24)
+        datebit = yesterday.strftime('%d/%m/%Y')
+        postdate = '{} {}'.format(datebit, postdate[postdate.rfind(',') + 1:])
+    if 'Today' in postdate:
+        datebit = datetime.date.today().strftime('%d/%m/%Y')
+        postdate = '{} {}'.format(datebit, postdate[postdate.rfind(',') + 1:])
+
+    return parser.parse('{} {}'.format(postdate, tzstring)).astimezone(tz.tzutc()) 
+
+
+def get_user_post_times(soup, author):
+
+    user_tz = get_timezone(soup)
+
+    usernames = soup.find_all('a', class_="username")
+    postdates = soup.find_all('span', class_="postdate old")
+
+    userposts = [get_datetime_from_postdate(posted.get_text(strip=True),  user_tz) for user, posted in zip(usernames, postdates) if author == user.get_text(strip=True)]
+
+    return userposts
+
+def validate_fic_page(year, posts):
+    return any([check_in_awards_year(year, date) for date in posts])
 
 
 def pretty_join(items, word='and'):
@@ -324,7 +354,7 @@ class Fic(SerebiiObject, models.Model):
             raise ValidationError(u"This thread does not seem to be a fanfic (it is not located in the Fan Fiction, Non-Pokémon Stories or Completed Fics forums). Please enter the link to a valid fanfic.")
         title_link = soup.find('span', class_="threadtitle").a
 
-        if post_id is not None:  # TODO: make it actually possible to nominate individual posts
+        if post_id is not None and False:  # TODO: make it actually possible to nominate individual posts
             # The fic starts in a particular post
             post = soup.find(id="post_%s" % post_id)
             title = post.find('h2', class_="posttitle").get_text(strip=True)
@@ -332,8 +362,7 @@ class Fic(SerebiiObject, models.Model):
 
             # Make sure this was posted in the awards year
             posted = post.find('span', class_="postdate old").get_text(strip=True)
-            datetimestring = posted + ' ' + get_timezone(soup)
-            posted_utc = parser.parse(datetimestring).astimezone(tz.tzutc())
+            posted_utc = get_datetime_from_postdate(posted,  get_timezone(soup))
 
             if not check_in_awards_year(int(settings.YEAR), posted_utc):
                 raise ValidationError(u"This fanfic is not eligible for this year's awards. Please nominate a story posted between 00:00 January 1st {} and 23:59 UTC December 31st {}.".format(settings.YEAR, settings.YEAR))
@@ -345,70 +374,63 @@ class Fic(SerebiiObject, models.Model):
             # We need to check whether the 'fic was UPDATED in the  awards year
             # First look at author's posts on the nominated page
             # If any are from the awards year, we don't need to go further
-            user_tz = get_timezone(soup)
-            valid = False
+            userposts = get_user_post_times(soup, str(author))
 
-            postdates = soup.find_all('span', class_="postdate old")
-            usernames = soup.find_all('a', class_="username")
+            if not validate_fic_page(int(settings.YEAR), userposts):
 
-            for index, user in enumerate(usernames):
-                if str(author) == user.get_text(strip=True):
-                    datetimestring = postdates[index].get_text(strip=True) + ' ' + user_tz
-                    posted_utc = parser.parse(datetimestring).astimezone(tz.tzutc())
-                    if check_in_awards_year(int(settings.YEAR), posted_utc):
-                        valid = True
-                        break
-
-                    if index == 0:
-                        # This is the author's first post on this page.
-                        # If this is also the first page of the thread,
-                        # and the post was made after the awards year,
-                        # the story cannot possibly be eligible.
-                        print 'First', datetimestring
-                        print posted_utc > datetime.datetime(int(settings.YEAR), 12, 31, 23, 59, tzinfo=tz.tzutc())
-                        try:
-                            if soup.find('span', class_="selected").get_text(strip=True) == '1':
-                                print 'First page'
-                        except AttributeError:
-                            pass
-
-                    if index == len(usernames) - 1:
-                        # This is the author's last post on this page.
-                        # If this is also the last page of the thread,
-                        # and the post was made before the awards year,
-                        # the story cannot possibly be eligible.
-                        print 'Last', datetimestring
-                        print posted_utc < datetime.datetime(int(settings.YEAR), 1, 1, 0, 0, tzinfo=tz.tzutc())
-                        try:
-                            print soup.find('form', class_='pagination').find('a', class_="popupctrl").get_text(strip=True)
-                        except AttributeError:
-                            # There are no other pages!
-                            # Since this is the last post,
-                            # and we've found no valid ones,
-                            # this thread is not eligible.
-                            print 'no further pages!'
-                            raise ValidationError(u"This fanfic is not eligible for this year's awards. Please nominate a story updated between 00:00 January 1st {} and 23:59 UTC December 31st {}.".format(settings.YEAR, settings.YEAR))
-                          
-
-            if not valid:
-                # Are there any more pages in the thread?
-                # If not, this is the end of the line
-                if soup.find('span', class_="prev_next"):
-                    # Okay, is this the last (most recent) page?
-                    # If so, and all posts are pre-awards year,
-                    # it can't possibly be eligible
-
-                    # Is this the first (oldest) page?
-                    # If so, and all posts are post-awards year,
-                    # it also can't possibly be eligible
-
-                    # Nothing left to do but fetch all the user's posts
-                    # in the thread for the awards year
-                    pass
-                else:
+                if not soup.find('span', class_="selected"):
+                    # This is the only page!
+                    # The story can't possibly be eligible.
                     raise ValidationError(u"This fanfic is not eligible for this year's awards. Please nominate a story updated between 00:00 January 1st {} and 23:59 UTC December 31st {}.".format(settings.YEAR, settings.YEAR))
 
-            raise ValidationError("Just so I don't have to keep deleting stuff from the database")
+                elif not soup.find('img', alt="Previous"):
+                    # This is the first page!
+                    if userposts[0] > datetime.datetime(int(settings.YEAR), 12, 31, 23, 59, tzinfo=tz.tzutc()):
+                        # If the first post was made after the end of the awards year,
+                        # the story can't possibly be eligible.
+                        raise ValidationError(u"This fanfic is not eligible for this year's awards. Please nominate a story updated between 00:00 January 1st {} and 23:59 UTC December 31st {}.".format(settings.YEAR, settings.YEAR))
+                elif not soup.find('img', alt='Next'):
+                    # This is the last page!
+                    # I don't believe this should be able to happen
+                    # But just in case...
+
+                    if userposts[-1] < datetime.datetime(int(settings.YEAR), 1, 1, 0, 0, tzinfo=tz.tzutc()):
+                        # If the first post was made before the beginning of the awards year,
+                        # the story can't possibly be eligible.
+                        raise ValidationError(u"This fanfic is not eligible for this year's awards. Please nominate a story updated between 00:00 January 1st {} and 23:59 UTC December 31st {}.".format(settings.YEAR, settings.YEAR))
+
+                # Nothing for it but to start working backward through the thread
+                # First, fetch the last page if we aren't there already
+                lastimg = soup.find('img', alt='Last')
+
+                if lastimg:
+                    nextlink = lastimg.parent['href']
+                    pagenum = int(nextlink[nextlink.rfind('page') + 4:])
+                else:
+                    # We start at this page - 1
+                    # I guess we might need to get this here?
+                    if thread_id is None:
+                        thread_id = FicPage.get_params_from_url(title_link['href'])['thread_id']
+
+                    pagenum = int(soup.find('span', class_="selected").get_text(strip=True))
+                    nextlink = ('showthread.php?{}/page{}'.format(thread_id, pagenum - 1))
+
+                while pagenum > 0:
+                    soup = get_soup('http://www.serebiiforums.com/{}'.format(nextlink))
+                    userposts = get_user_post_times(soup, str(author))
+
+                    if not validate_fic_page(int(settings.YEAR), userposts):
+                        # If the author's first post on this page is from before the awards year,
+                        # the story can't possibly be eligible.
+                        if userposts[0] < datetime.datetime(int(settings.YEAR), 1, 1, 0, 0, tzinfo=tz.tzutc()):
+                            raise ValidationError(u"This fanfic is not eligible for this year's awards. Please nominate a story updated between 00:00 January 1st {} and 23:59 UTC December 31st {}.".format(settings.YEAR, settings.YEAR))
+
+                        nextlink = ('showthread.php?{}/page{}'.format(thread_id, pagenum - 1))
+                        pagenum -= 1
+
+                    else:
+                        break
+
         if thread_id is None:
             thread_id = FicPage.get_params_from_url(title_link['href'])['thread_id']
         obj = cls(title=title, thread_id=thread_id, post_id=post_id)

--- a/serebii/models.py
+++ b/serebii/models.py
@@ -44,8 +44,18 @@ def get_user_post_times(soup, author):
 
     return userposts
 
+
 def validate_fic_page(year, posts):
     return any([check_in_awards_year(year, date) for date in posts])
+
+
+def get_timezone(page):
+    tz_text = page.find('div', id="footer_time").get_text()
+    tz_bits = tz_text.split(' ')
+    tz = tz_bits[4][:-1]
+
+    tz = '{}{:0>2d}00'.format(tz[0], int(tz[1:]))
+    return tz
 
 
 def pretty_join(items, word='and'):
@@ -64,15 +74,6 @@ def get_post_author(post):
     username = user_link.strong.get_text(strip=True)
     user_id = MemberPage.get_params_from_url(user_link['href'])['user_id']
     return Member(user_id=user_id, username=username)
-
-
-def get_timezone(page):
-    tz_text = page.find('div', id="footer_time").get_text()
-    tz_bits = tz_text.split(' ')
-    tz = tz_bits[4][:-1]
-
-    tz = '{}{:0>2d}00'.format(tz[0], int(tz[1:]))
-    return tz
 
 
 class SerebiiPage(object):


### PR DESCRIPTION
Important note: this implementation adds dateutil as a dependency because SPPf uses a date format for posts that most basic datetime implementations don't like to parse. However, it would be possible for me to rewrite this to require no dependencies if you'd rather not; it'll just require some fiddly regex crap.

There is no easy way to validate a long multichapter 'fic, especially because I _think_ the way the URL field works is to strip the page number off the URL, meaning that the first page is the one fetched, which could easily be from several years ago. Even if it didn't, a lot of people are probably going to nominate using the bare URL (i.e. first page) anyway. Searching for all of the author's posts in the thread requires a _minimum_ two requests (one to fetch a valid security token, the second to search), and because VBulletin's search system is crap it's not possible to confine the search just to the awards year, which could give an immediate yes/no on eligibility. Instead, if the page used for the nomination url has no eligible posts, the validator begins by fetching the last page in the thread, then walking back one page at a time until it either finds an eligible post or finds posts earlier than the eligibility window. I think that _in practice_ this will require the fewest additional requests and therefore the least amount of time, but it is undeniably slow and clunky, especially if the admin has the board set to display the default number of posts per page (join the 100-per-page club!).
