### PR TITLE
Remove votes/nominations from previous years from localStorage

### DIFF
--- a/awards/templates/nomination.html
+++ b/awards/templates/nomination.html
@@ -236,7 +236,8 @@ Please correct the errors below.
     var current_nominations;
 
     // Load nominations from localStorage if possible
-    if (localStorage && localStorage.getItem("current_nominations")) {
+    if (localStorage && localStorage.getItem("current_nominations") && localStorage.getItem("current_year") === String({{year}})) {
+
         current_nominations = $.parseJSON(localStorage.getItem("current_nominations"));
 
         for (var saved_nomination in current_nominations) {
@@ -254,14 +255,14 @@ Please correct the errors below.
                     current_nominations[saved_nomination].pk === $('#' + paired_form + '-nominee_0').val()
                 ) {
                     // This nomination is the same as the paired one, on which we have no saved information. This is most likely because we entered a nomination into the second form, which was then loaded into the first form when it came back from the server. Let's put our saved stuff into the paired form instead and pretend we're dealing with that!
-                    current_nominations[paired_form] = current_nominations[saved_nomination];
+                   current_nominations[paired_form] = current_nominations[saved_nomination];
                     saved_nomination = paired_form;
                 }
             }
             // First, redo the lookup on this nomination if possible
             if (current_nominations[saved_nomination].hasOwnProperty('url')) {
                 var $unverified_nomination;
-
+  
                 if (current_nominations[saved_nomination].type === 'post' || current_nominations[saved_nomination].type == 'thread') {
                     // Single-post nominations need special handling
                     $unverified_nomination = $('#' + saved_nomination + '-fic_1');
@@ -270,7 +271,7 @@ Please correct the errors below.
                 }
                 else {
                     if (current_nominations[saved_nomination].type === 'fic') {
-                        $unverified_nomination = $('#' + saved_nomination + '-fic_1');
+                       $unverified_nomination = $('#' + saved_nomination + '-fic_1');
                     }
                     else {
                         $unverified_nomination = $('#' + saved_nomination + '-nominee_1');
@@ -316,7 +317,7 @@ Please correct the errors below.
                         nomination_info = authors[current_nominations[saved_nomination].pk];
                         nomination_info.name = nomination_info.username;
                     }
-                }
+               }
 
                 if (nomination_info) {
                     nomination_info.pk = current_nominations[saved_nomination].pk
@@ -350,7 +351,22 @@ Please correct the errors below.
         }
     }
     else {
-        current_nominations = {};
+
+        console.log(localStorage.getItem("current_year") === String({{year}}));
+
+        // Delete any existing nominations
+        localStorage.removeItem("current_nominations");
+
+        // Also delete any votes; any existing ones are from wrong year
+        localStorage.removeItem("current_votes");
+
+        // Initialize the nominations object
+        var current_nominations = {};
+
+        // Set the year if possible
+        if (localStorage && JSON) {
+            localStorage.setItem("current_year", {{year}});
+        }
     }
 
     function update_progress() {

--- a/awards/templates/nomination.html
+++ b/awards/templates/nomination.html
@@ -262,7 +262,7 @@ Please correct the errors below.
             // First, redo the lookup on this nomination if possible
             if (current_nominations[saved_nomination].hasOwnProperty('url')) {
                 var $unverified_nomination;
- 
+
                 if (current_nominations[saved_nomination].type === 'post' || current_nominations[saved_nomination].type == 'thread') {
                     // Single-post nominations need special handling
                     $unverified_nomination = $('#' + saved_nomination + '-fic_1');

--- a/awards/templates/nomination.html
+++ b/awards/templates/nomination.html
@@ -255,14 +255,14 @@ Please correct the errors below.
                     current_nominations[saved_nomination].pk === $('#' + paired_form + '-nominee_0').val()
                 ) {
                     // This nomination is the same as the paired one, on which we have no saved information. This is most likely because we entered a nomination into the second form, which was then loaded into the first form when it came back from the server. Let's put our saved stuff into the paired form instead and pretend we're dealing with that!
-                   current_nominations[paired_form] = current_nominations[saved_nomination];
+                    current_nominations[paired_form] = current_nominations[saved_nomination];
                     saved_nomination = paired_form;
                 }
             }
             // First, redo the lookup on this nomination if possible
             if (current_nominations[saved_nomination].hasOwnProperty('url')) {
                 var $unverified_nomination;
-  
+ 
                 if (current_nominations[saved_nomination].type === 'post' || current_nominations[saved_nomination].type == 'thread') {
                     // Single-post nominations need special handling
                     $unverified_nomination = $('#' + saved_nomination + '-fic_1');
@@ -271,7 +271,7 @@ Please correct the errors below.
                 }
                 else {
                     if (current_nominations[saved_nomination].type === 'fic') {
-                       $unverified_nomination = $('#' + saved_nomination + '-fic_1');
+                        $unverified_nomination = $('#' + saved_nomination + '-fic_1');
                     }
                     else {
                         $unverified_nomination = $('#' + saved_nomination + '-nominee_1');
@@ -279,7 +279,7 @@ Please correct the errors below.
 
                     $unverified_nomination.val(current_nominations[saved_nomination].url);
                     lookup($unverified_nomination, current_nominations[saved_nomination].type);
-                }
+               }
             }
             else if (current_nominations[saved_nomination].hasOwnProperty('pk')) {
                 // The item should be in the db already, just not in the drop-down

--- a/awards/templates/nomination.html
+++ b/awards/templates/nomination.html
@@ -279,7 +279,7 @@ Please correct the errors below.
 
                     $unverified_nomination.val(current_nominations[saved_nomination].url);
                     lookup($unverified_nomination, current_nominations[saved_nomination].type);
-               }
+                }
             }
             else if (current_nominations[saved_nomination].hasOwnProperty('pk')) {
                 // The item should be in the db already, just not in the drop-down
@@ -317,7 +317,7 @@ Please correct the errors below.
                         nomination_info = authors[current_nominations[saved_nomination].pk];
                         nomination_info.name = nomination_info.username;
                     }
-               }
+                }
 
                 if (nomination_info) {
                     nomination_info.pk = current_nominations[saved_nomination].pk

--- a/awards/templates/voting.html
+++ b/awards/templates/voting.html
@@ -81,6 +81,7 @@
 
     function update_progress() {
 
+        var current_votes = {};
         var unvoted_categories = {};
         var total_votes = 0;
 
@@ -89,6 +90,7 @@
             if (typeof vote !== 'undefined') {
                 if (vote === "") {
                     unvoted_categories[$(this).attr("id")] = $(this).find("legend").text();
+
                 }
                 else {
                     current_votes[$(this).attr("id")] = vote;

--- a/awards/templates/voting.html
+++ b/awards/templates/voting.html
@@ -49,7 +49,7 @@
     $("body").append('<div id="progress-tracker" class="collapse-container"><div class="collapse-marker collapse-button"><span class="glyphicon glyphicon-chevron-up"></span> Your Votes (<span class="current-vote-field">0</span>/{{award_requirement}})</div><div class="collapse-body"><span class="glyphicon glyphicon-chevron-down collapse-button pull-right"></span> You have cast <span class="current-vote-field collapse-button">0</span> vote(s).<p class="collapse-button">You must cast <span id="required-vote-field" class="collapse-button">0</span> more to submit.</p></div></div>');
 
     // Load votes from localStorage if possible
-    if (localStorage && localStorage.getItem("current_votes")) {
+    if (localStorage && localStorage.getItem("current_votes") && localStorage.getItem("current_year") === String({{year}})) {
         var current_votes = $.parseJSON(localStorage.getItem("current_votes"));
 
         for (var set_vote in current_votes) {
@@ -64,7 +64,19 @@
         }
 
     } else {
+        // Delete any existing votes
+        localStorage.removeItem("current_votes");
+
+        // Also delete any nominations: any existing ones are from wrong year
+        localStorage.removeItem("current_nominations");
+
+        // Initialize vote object
         var current_votes = {};
+
+        // If possible, save the current year
+        if (localStorage && JSON) {
+            localStorage.setItem("current_year", {{year}});
+        }
     }
 
     function update_progress() {


### PR DESCRIPTION
Previously votes and nominations would remain in localStorage indefinitely (until removed by the user). This could result in a user returning to the site for the next year's nominations or voting and have the form attempt to prefill with saved votes/nominations from the previous year, which is probably undesirable.

This pull request adds a check of the stored current_year variable and whether it's equal to the app's year setting, then deletes votes/nominations from localStorage if it is not.